### PR TITLE
Read secrets from external file

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,9 @@ driver: ldap
 ldap:
   url: ldap://myldapserver
   bind_user: uid=myadmin,ou=people,dc=foobar,dc=com
+  # Either bind_pass or bind_pass_file must be specified
   bind_pass: myadminpassword
+  # bind_pass_file: /path/to/password/file
   basedn: ou=people,dc=foobar,dc=com
   filter: (uid=*)
   user_attr: uid

--- a/README.md
+++ b/README.md
@@ -177,12 +177,14 @@ With the following configuration files:
 driver: sql
 database:
   driver: "postgres" # available drivers are `postgres`, `mysql`, or `sqlite`
+  # Either url or url_file must be specified, but not both
   url: "postgres://user:password@localhost:5432/dbname?sslmode=disable"
+  # url_file: /path/to/url/file
   table: "users"
 
   # this is the column of the specified table that is searched for the requested
   # `acct:` resource value. for example, if we get a request for
-  # `acct:bob@example.com`, the row of `users` where `email` = `bob@example.com` 
+  # `acct:bob@example.com`, the row of `users` where `email` = `bob@example.com`
   # will be fetched.
   key_column: "email"
   

--- a/configs/examples/ldap/config.yml
+++ b/configs/examples/ldap/config.yml
@@ -2,7 +2,9 @@ driver: ldap
 ldap:
   url: ldaps://ldap.example.com
   bind_user: cn=root,dc=example,dc=com
+  # Either bind_pass or bind_pass_file must be specified, but not both
   bind_pass: password
+  # bind_pass_file: /path/to/password/file
   basedn: ou=Users,dc=example,dc=com
   filter: (memberOf=cn=public,ou=Groups,dc=example,dc=com)
   user_attr: uid

--- a/configs/examples/sql/config.yml
+++ b/configs/examples/sql/config.yml
@@ -1,7 +1,9 @@
 driver: sql
 database:
   driver: "postgres"
+  # Either url or url_file must be specified, but not both
   url: "postgres://user:password@localhost:5432/dbname?sslmode=disable"
+  # url_file: /path/to/url/file
   table: "users"
   key_column: "email"
   column_names:

--- a/internal/config/main.go
+++ b/internal/config/main.go
@@ -15,6 +15,7 @@ type ConfigWizard interface {
 	processConfigYaml([]byte) (*Configuration, error)
 	GetConfiguration() (*Configuration, error)
 	processLDAPBindPassword(config *Configuration) error
+	processDatabaseURL(config *Configuration) error
 }
 
 type configWizard struct {
@@ -44,6 +45,7 @@ type LDAPConfiguration struct {
 type DatabaseConfiguration struct {
 	Driver      string   `yaml:"driver"`       // e.g., "postgres"
 	URL         string   `yaml:"url"`          // Database connection URL
+	URLFile     string   `yaml:"url_file"`     // File containing database connection URL
 	Table       string   `yaml:"table"`        // Table name
 	KeyColumn   string   `yaml:"key_column"`   // Column to search by (e.g., "uid")
 	ColumnNames []string `yaml:"column_names"` // Mapping of column names to template variables

--- a/internal/config/main.go
+++ b/internal/config/main.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 
@@ -9,8 +10,11 @@ import (
 
 type ConfigWizard interface {
 	readConfigFile() ([]byte, error)
+	readSecretFromFile(filePath string) (string, error)
 	deserializeConfigYaml([]byte) (*Configuration, error)
+	processConfigYaml([]byte) (*Configuration, error)
 	GetConfiguration() (*Configuration, error)
+	processLDAPBindPassword(config *Configuration) error
 }
 
 type configWizard struct {
@@ -26,14 +30,15 @@ type FileConfiguration struct {
 }
 
 type LDAPConfiguration struct {
-	URL        string   `yaml:"url"`
-	BindUser   string   `yaml:"bind_user"`
-	BindPass   string   `yaml:"bind_pass"`
-	BaseDN     string   `yaml:"basedn"`
-	Filter     string   `yaml:"filter"`
-	UserAttr   string   `yaml:"user_attr"`
-	Attributes []string `yaml:"attributes"`
-	Template   string   `yaml:"template"`
+	URL          string   `yaml:"url"`
+	BindUser     string   `yaml:"bind_user"`
+	BindPass     string   `yaml:"bind_pass"`
+	BindPassFile string   `yaml:"bind_pass_file"`
+	BaseDN       string   `yaml:"basedn"`
+	Filter       string   `yaml:"filter"`
+	UserAttr     string   `yaml:"user_attr"`
+	Attributes   []string `yaml:"attributes"`
+	Template     string   `yaml:"template"`
 }
 
 type DatabaseConfiguration struct {
@@ -73,15 +78,91 @@ func (wiz configWizard) deserializeConfigYaml(
 	return &config, nil
 }
 
+func (wiz configWizard) processConfigYaml(
+	configYaml []byte,
+) (*Configuration, error) {
+	config, err := wiz.deserializeConfigYaml(configYaml)
+	if err != nil {
+		return nil, fmt.Errorf("cannot unmarshal config YAML: %w", err)
+	}
+
+	if err := wiz.processLDAPBindPassword(config); err != nil {
+		return nil, err
+	}
+
+	if err := wiz.processDatabaseURL(config); err != nil {
+		return nil, err
+	}
+
+	return config, nil
+}
+
+func (wiz configWizard) readSecretFromFile(filePath string) (string, error) {
+	secretBytes, err := os.ReadFile(filePath)
+	if err != nil {
+		return "", fmt.Errorf("unable to read secret from %s: %w", filePath, err)
+	}
+
+	return string(bytes.TrimSpace(secretBytes)), nil
+}
+
+func (wiz configWizard) processLDAPBindPassword(config *Configuration) error {
+	if config.LDAPConfiguration == nil {
+		return nil
+	}
+
+	hasBindPass := config.LDAPConfiguration.BindPass != ""
+	hasBindPassFile := config.LDAPConfiguration.BindPassFile != ""
+
+	if hasBindPass == hasBindPassFile {
+		return fmt.Errorf("must specify either bind_pass or bind_pass_file")
+	}
+
+	if config.LDAPConfiguration.BindPassFile != "" {
+		password, err := wiz.readSecretFromFile(config.LDAPConfiguration.BindPassFile)
+		if err != nil {
+			return fmt.Errorf("cannot read LDAP bind password file: %w", err)
+		}
+
+		config.LDAPConfiguration.BindPass = password
+	}
+
+	return nil
+}
+
+func (wiz configWizard) processDatabaseURL(config *Configuration) error {
+	if config.DatabaseConfiguration == nil {
+		return nil
+	}
+
+	hasURL := config.DatabaseConfiguration.URL != ""
+	hasURLFile := config.DatabaseConfiguration.URLFile != ""
+
+	if hasURL == hasURLFile {
+		return fmt.Errorf("must specify either url or url_file")
+	}
+
+	if config.DatabaseConfiguration.URLFile != "" {
+		url, err := wiz.readSecretFromFile(config.DatabaseConfiguration.URLFile)
+		if err != nil {
+			return fmt.Errorf("cannot read database URL file: %w", err)
+		}
+
+		config.DatabaseConfiguration.URL = url
+	}
+
+	return nil
+}
+
 func (wiz configWizard) GetConfiguration() (*Configuration, error) {
 	configYaml, err := wiz.readConfigFile()
 	if err != nil {
 		return nil, fmt.Errorf("cannot read config file: %w", err)
 	}
 
-	config, err := wiz.deserializeConfigYaml(configYaml)
+	config, err := wiz.processConfigYaml(configYaml)
 	if err != nil {
-		return nil, fmt.Errorf("cannot unmarshal config YAML: %w", err)
+		return nil, err
 	}
 
 	return config, nil

--- a/internal/config/main_test.go
+++ b/internal/config/main_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"errors"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -15,7 +16,7 @@ file:
   directory: /foo/bar
 `
 
-	wizard := configWizard {}
+	wizard := configWizard{}
 
 	t.Run("can deserialize config yaml", func(t *testing.T) {
 		got, _ := wizard.deserializeConfigYaml([]byte(testYaml))
@@ -25,12 +26,79 @@ file:
 			FileConfiguration: &FileConfiguration{
 				Directory: "/foo/bar",
 			},
-			LDAPConfiguration: nil,
+			LDAPConfiguration:     nil,
 			DatabaseConfiguration: nil,
 		}
 
 		if !cmp.Equal(got, want) {
-			t.Errorf("got: %+v, want: %+v",	got, want)
+			t.Errorf("got: %+v, want: %+v", got, want)
+		}
+	})
+}
+
+func TestConfigWizardGetConfigurationWithLDAPBindPassFile(t *testing.T) {
+	testYaml := `
+driver: ldap
+ldap:
+  bind_pass_file: ../../test/secret_file
+`
+	passwordContent := "test_secret"
+	passwordFile := "../../test/secret_file"
+
+	wizard := configWizard{}
+
+	t.Run("config wizard can read password from file", func(t *testing.T) {
+		got, err := wizard.processConfigYaml([]byte(testYaml))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if got.LDAPConfiguration.BindPass != passwordContent {
+			t.Errorf("expected BindPass to be '%s', got '%s'", passwordContent, got.LDAPConfiguration.BindPass)
+		}
+
+		if got.LDAPConfiguration.BindPassFile != passwordFile {
+			t.Errorf("expected BindPassFile to be '%s', got '%s'", passwordFile, got.LDAPConfiguration.BindPassFile)
+		}
+	})
+}
+
+func TestConfigWizardGetConfigurationWithBothLDAPPasswordAndFile(t *testing.T) {
+	testYaml := `
+driver: ldap
+ldap:
+  bind_pass: password
+  bind_pass_file: ../../test/secret_file
+`
+	wizard := configWizard{}
+	t.Run("config wizard errors when both bind_pass and bind_pass_file are specified", func(t *testing.T) {
+		_, err := wizard.processConfigYaml([]byte(testYaml))
+
+		if err == nil {
+			t.Fatal("expected error when both bind_pass and bind_pass_file are specified")
+		}
+
+		if err.Error() != "must specify either bind_pass or bind_pass_file" {
+			t.Errorf("unexpected error message: %v", err)
+		}
+	})
+}
+
+func TestConfigWizardGetConfigurationWithMissingLDAPPasswordFile(t *testing.T) {
+	testYaml := `
+driver: ldap
+ldap:
+  bind_pass_file: /non/existent/file
+`
+	wizard := configWizard{}
+	t.Run("config wizard errors when LDAP password file is missing", func(t *testing.T) {
+		_, err := wizard.processConfigYaml([]byte(testYaml))
+		if err == nil {
+			t.Fatal("expected error when LDAP password file is missing")
+		}
+
+		if !strings.Contains(err.Error(), "cannot read LDAP bind password file") {
+			t.Errorf("unexpected error message: %v", err)
 		}
 	})
 }
@@ -40,7 +108,6 @@ func TestConfigWizardGetConfiguration(t *testing.T) {
 		wizard := NewConfigWizard("../../test/config.yml")
 
 		got, err := wizard.GetConfiguration()
-
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/test/secret_file
+++ b/test/secret_file
@@ -1,0 +1,1 @@
+test_secret


### PR DESCRIPTION
To avoid storing secrets in the configuration file itself, I added `ldap.bind_pass_file` and `database.url_file`, which allow moving these values to dedicated secrets files.