### PR TITLE
Add config env expansion

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,22 @@ file:
   directory: /etc/carpal/resources/
 ```
 
-You can change the location of the configuration file with the `CONFIG_FILE`
+This configuration file primarily specifies how carpal interacts with the
+different data sources it can read from (see [Drivers](#drivers) for more). You
+can change the location of the configuration file with the `CONFIG_FILE`
 environment variable.
+
+### Environment Variables
+
+| Name | Values | Description |
+|:--|:--|:--|
+| `LOG_LEVEL`| `error`, `warn`, `info`, `debug` | Configures the minimum level of logs emitted to stdout. Default is `info`. See Go's `log/slog` [docs](https://pkg.go.dev/log/slog#Level) for more info. |
+| `CONFIG_FILE` | filepath | Absolute path of the config file in the filesystem. |
+| `EXPAND_CONFIG_ENV_VARS` | `true`, empty | If set to a non-empty string, this enables expansion of environment variables within the configuration file. See the [LDAP](#ldap-driver) and [SQL](#sql-driver) sections for examples. |
+| `PORT` | any port number |  Specifies the TCP port number that the web server will run on. |
+
+
+## [Drivers](#drivers)
 
 Carpal allows for the configuration of multiple different types of data sources.
 By default, the `file` driver is used, but `ldap` and `sql` drivers are also available
@@ -80,7 +94,7 @@ for fetching users from an LDAP directory or SQL database respectively.
 
 ### [File Driver](#file-driver)
 
-The example file configures the file driver by default. The file driver simply
+The minimal config file from above enables the file driver. The file driver simply
 reads a YAML file representing a resource from a specified directory, converts
 it to JSON, and returns it as an HTTP response to the client.
 
@@ -124,8 +138,11 @@ driver: ldap
 ldap:
   url: ldap://myldapserver
   bind_user: uid=myadmin,ou=people,dc=foobar,dc=com
-  # Either bind_pass or bind_pass_file must be specified
   bind_pass: myadminpassword
+  # with the EXPAND_CONFIG_ENV_VARS env var set to `true`, you can also do:
+  # bind_pass: ${BIND_PASS}
+
+  # or specify a file containing the bind pass:
   # bind_pass_file: /path/to/password/file
   basedn: ou=people,dc=foobar,dc=com
   filter: (uid=*)
@@ -177,8 +194,12 @@ With the following configuration files:
 driver: sql
 database:
   driver: "postgres" # available drivers are `postgres`, `mysql`, or `sqlite`
-  # Either url or url_file must be specified, but not both
   url: "postgres://user:password@localhost:5432/dbname?sslmode=disable"
+  # with the EXPAND_CONFIG_ENV_VARS env var set to `true`, you can also do:
+  # url: ${DATABASE_URL}
+
+  # or specify a file containing the bind pass:
+  # bind_pass_file: /path/to/password/file
   # url_file: /path/to/url/file
   table: "users"
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -19,7 +19,9 @@ func main() {
 		fileLocation = "/etc/carpal/config.yml"
 	}
 
-	configWizard := config.NewConfigWizard(fileLocation)
+	expandEnvs := os.Getenv("EXPAND_CONFIG_ENV_VARS") != ""
+
+	configWizard := config.NewConfigWizard(fileLocation, expandEnvs)
 	config, err := configWizard.GetConfiguration()
 	if err != nil {
 		log.Fatalf("could not load configuration: %v", err)

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1690031011,
-        "narHash": "sha256-kzK0P4Smt7CL53YCdZCBbt9uBFFhE0iNvCki20etAf4=",
+        "lastModified": 1757745802,
+        "narHash": "sha256-hLEO2TPj55KcUFUU1vgtHE9UEIOjRcH/4QbmfHNF820=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "12303c652b881435065a98729eb7278313041e49",
+        "rev": "c23193b943c6c689d70ee98ce3128239ed9e32d1",
         "type": "github"
       },
       "original": {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/peeley/carpal
 
-go 1.20
+go 1.25
 
 require (
 	github.com/go-ldap/ldap/v3 v3.4.8

--- a/internal/config/main.go
+++ b/internal/config/main.go
@@ -20,10 +20,11 @@ type ConfigWizard interface {
 
 type configWizard struct {
 	ConfigFileLocation string
+	ExpandEnvs bool
 }
 
-func NewConfigWizard(configFileLocation string) ConfigWizard {
-	return configWizard{configFileLocation}
+func NewConfigWizard(configFileLocation string, expandEnvs bool) ConfigWizard {
+	return configWizard{configFileLocation, expandEnvs}
 }
 
 type FileConfiguration struct {
@@ -63,6 +64,13 @@ func (wiz configWizard) readConfigFile() ([]byte, error) {
 	contents, err := os.ReadFile(wiz.ConfigFileLocation)
 	if err != nil {
 		return nil, fmt.Errorf("could not read config file: %w", err)
+	}
+
+	if wiz.ExpandEnvs {
+		contentsString := string(contents)
+		contentsString = os.ExpandEnv(contentsString)
+
+		return []byte(contentsString), nil
 	}
 
 	return contents, nil

--- a/internal/config/main.go
+++ b/internal/config/main.go
@@ -3,6 +3,7 @@ package config
 import (
 	"bytes"
 	"fmt"
+	"log/slog"
 	"os"
 
 	"gopkg.in/yaml.v3"
@@ -69,6 +70,7 @@ func (wiz configWizard) readConfigFile() ([]byte, error) {
 	if wiz.ExpandEnvs {
 		contentsString := string(contents)
 		contentsString = os.ExpandEnv(contentsString)
+		slog.Debug(fmt.Sprintf("expanded environment variables in config: \n%s", contentsString))
 
 		return []byte(contentsString), nil
 	}

--- a/internal/driver/file/main.go
+++ b/internal/driver/file/main.go
@@ -3,7 +3,7 @@ package file
 import (
 	"errors"
 	"fmt"
-	"log"
+	"log/slog"
 	"os"
 	"path"
 
@@ -28,7 +28,7 @@ func (d fileDriver) GetResource(name string) (*resource.Resource, error) {
 
 	resourceFile, err := os.ReadFile(path.Join(baseDirectory, name))
 	if err != nil {
-		log.Printf("unable to read resource file: %v", err)
+		slog.Error("unable to read resource file", "err", err)
 		if errors.Is(err, os.ErrNotExist) {
 			return nil, driver.ResourceNotFound{ResourceName: name}
 		} else {
@@ -39,7 +39,7 @@ func (d fileDriver) GetResource(name string) (*resource.Resource, error) {
 	var resource resource.Resource
 	err = yaml.Unmarshal(resourceFile, &resource)
 	if err != nil {
-		log.Printf("unable to unmarshal resource file contents: %v", err)
+		slog.Error("unable to unmarshal resource file contents", "err", err)
 		return nil, fmt.Errorf("could not unmarshal file to JRD: %w", err)
 	}
 

--- a/test/config-with-envs.yml
+++ b/test/config-with-envs.yml
@@ -1,0 +1,10 @@
+driver: sql
+database:
+  driver: "postgres"
+  url: ${DATABASE_URL}
+  table: "users"
+  key_column: "email"
+  column_names:
+    - "email"
+    - "handle"
+    - "name"


### PR DESCRIPTION
Fixes https://github.com/peeley/carpal/issues/10. 

This PR adds environment variable expansion to the config file. For example, running carpal with a config like the following:

```yaml
driver: sql
database:
  driver: "postgres"
  url: ${DATABASE_URL}
  table: "users"
  key_column: "email"
  column_names:
    - "email"
    - "handle"
    - "name"
```

and the env var `DATABASE_URL=postgres://foobar`, the config will be expanded to:

```yaml
driver: sql
database:
  driver: "postgres"
  url: postgres://foobar
  table: "users"
  key_column: "email"
  column_names:
    - "email"
    - "handle"
    - "name"
```

Because of potential collisions with the env var syntax, env var expansion must be enabled by setting the `EXPAND_CONFIG_ENV_VARS` env var to any non-empty value (e.g., `EXPAND_CONFIG_ENV_VARS=true`). There already exists the option to supply LDAP passwords and database URLs through files, but this provides an additional and more general solution to supplying potentially sensitive credentials to the config file.