### PR TITLE
Properly set Content-Type header to application/jrd+json

### DIFF
--- a/internal/handler/main.go
+++ b/internal/handler/main.go
@@ -80,7 +80,7 @@ func (handler resourceHandler) Handle(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.WriteHeader(http.StatusOK)
 	w.Header().Add("Content-Type", "application/jrd+json")
+	w.WriteHeader(http.StatusOK)
 	w.Write(JRD)
 }

--- a/internal/handler/main_test.go
+++ b/internal/handler/main_test.go
@@ -35,7 +35,7 @@ func TestResourceHandlerFileDriver(t *testing.T) {
 			t.Fatalf("expected 200 OK, got %v", responseRecorder.Code)
 		}
 
-		responseHeaders := responseRecorder.HeaderMap
+		responseHeaders := responseRecorder.Result().Header
 
 		if len(responseHeaders["Content-Type"]) != 1 ||
 			responseHeaders["Content-Type"][0] != "application/jrd+json" {
@@ -68,7 +68,7 @@ func TestResourceHandlerFileDriver(t *testing.T) {
 			t.Fatalf("expected 200 OK, got %v", responseRecorder.Code)
 		}
 
-		responseHeaders := responseRecorder.HeaderMap
+		responseHeaders := responseRecorder.Result().Header
 
 		if len(responseHeaders["Content-Type"]) != 1 ||
 			responseHeaders["Content-Type"][0] != "application/jrd+json" {
@@ -101,7 +101,7 @@ func TestResourceHandlerFileDriver(t *testing.T) {
 			t.Fatalf("expected 200 OK, got %v", responseRecorder.Code)
 		}
 
-		responseHeaders := responseRecorder.HeaderMap
+		responseHeaders := responseRecorder.Result().Header
 
 		if len(responseHeaders["Content-Type"]) != 1 ||
 			responseHeaders["Content-Type"][0] != "application/jrd+json" {


### PR DESCRIPTION
Fixes https://github.com/peeley/carpal/issues/12.

This PR fixes a bug where out-of-order calls to `WriteHeader` and `Header().Add` fail to set the `Content-Type` of responses to `application/jrd+json`, which defaults to `text/plain`.